### PR TITLE
Skip test image in Dist::Zilla GatherDir step

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -10,6 +10,10 @@ repository = github
 bugtracker_web = https://github.com/doy/web-request/issues
 bugtracker_mailto =
 
+[Encoding]
+encoding = bytes
+filename = t/data/baybridge.jpg  ; this file is an image
+
 [AutoPrereqs]
 
 [ContributorsFromGit]


### PR DESCRIPTION
When building this dist locally, I got the following error when running `dzil listdeps`:

```
Could not decode UTF-8 t/data/baybridge.jpg; filename set by GatherDir
(Dist::Zilla::Plugin::GatherDir line 231); encoded_content added by
@DOY/GatherDir (Dist::Zilla::Plugin::GatherDir line 232); error was:
UTF-8 "\xFF" does not map to Unicode at <path>/site_perl/5.32.1/Dist/Zilla/Role/File.pm line 147.
; maybe you need the [Encoding] plugin to specify an encoding at
<path>/site_perl/5.32.1/Dist/Zilla/Role/File.pm line 171.
```

It seems that `GatherDir` tries to read the binary image file as text and fails.  The fix suggested in the error message did the trick: I specified the `baybridge.jpg` test data file as being `bytes` (as suggested by the `Dist::Zilla::Plugin::Encoding` docs) and the error no longer occurs.  Thus, the dependencies are able to be listed and installed so that all prereqs are available before running the test suite.

This pull request is submitted in the hope that it is useful. If you have any questions or comments, I'm more than happy to update it and resubmit as necessary.