### PR TITLE
Fix D::Z PkgVersion no blank line for VERSION warnings

### DIFF
--- a/lib/Web/Request.pm
+++ b/lib/Web/Request.pm
@@ -1,4 +1,5 @@
 package Web::Request;
+
 use Moose;
 # ABSTRACT: common request class for web frameworks
 

--- a/lib/Web/Request/Types.pm
+++ b/lib/Web/Request/Types.pm
@@ -1,4 +1,5 @@
 package Web::Request::Types;
+
 use strict;
 use warnings;
 

--- a/lib/Web/Request/Upload.pm
+++ b/lib/Web/Request/Upload.pm
@@ -1,4 +1,5 @@
 package Web::Request::Upload;
+
 use Moose;
 # ABSTRACT: class representing a file upload
 

--- a/lib/Web/Response.pm
+++ b/lib/Web/Response.pm
@@ -1,4 +1,5 @@
 package Web::Response;
+
 use Moose;
 # ABSTRACT: common response class for web frameworks
 


### PR DESCRIPTION
When running the test suite via `dzil test`, the following warnings appear:

```
[@DOY/PkgVersion] no blank line for $VERSION after package Web::Request statement in lib/Web/Request.pm line 1
[@DOY/PkgVersion] no blank line for $VERSION after package Web::Request::Types statement in lib/Web/Request/Types.pm line 1
[@DOY/PkgVersion] no blank line for $VERSION after package Web::Request::Upload statement in lib/Web/Request/Upload.pm line 1
[@DOY/PkgVersion] no blank line for $VERSION after package Web::Response statement in lib/Web/Response.pm line 1
```

The `PkgVersion` plugin requires a blank line after the `package` statement.  This change adds the required blank lines thus removing the warnings from the test output.

This PR is submitted in the hope that it is useful. If you want me to change anything, please let me know and I'll be happy to update and resubmit as necessary.