### PR TITLE
Add missing ABSTRACT for Dist::Zilla PodWeaver

### DIFF
--- a/lib/Web/Request/Types.pm
+++ b/lib/Web/Request/Types.pm
@@ -1,6 +1,7 @@
 package Web::Request::Types;
 use strict;
 use warnings;
+# ABSTRACT: package defining subtypes for this distribution
 
 use Moose::Util::TypeConstraints;
 


### PR DESCRIPTION
When running the test suite via `dzil test`, the following warning appears:

```
[@DOY/PodWeaver] [@Default/Name] couldn't find abstract in lib/Web/Request/Types.pm
```

This change adds the missing abstract information with what is hopefully a sensible description of this file's contents.  Adding the ABSTRACT has also removed the warning.

As with all of my PRs, they're submitted in the hope that they are useful. Please let me know if you want anything changed and I'll be more than happy to update and resubmit as necessary.