### PR TITLE
Document the encoding behaviour when using new_response()

### DIFF
--- a/lib/Web/Request.pm
+++ b/lib/Web/Request.pm
@@ -722,7 +722,8 @@ single value.
 
 =method new_response(@params)
 
-Returns a new response object, passing C<@params> to its constructor.
+Returns a new response object, passing C<@params> to its constructor. If the
+request's encoding is defined, this is applied to the response object.
 
 =method env
 


### PR DESCRIPTION
As mentioned in #3, when this method is called, the request's encoding is used for the response object's encoding.  The observation in #3 matches the code and the documentation change implemented here tries to make this behaviour clearer.

If I've managed to get the sense of the code correct, and to have documented this behaviour correctly, then this change would resolve the issue raised in #3.  If you'd like this explanation changed, please let me know and I'll update as necessary and resubmit :-)